### PR TITLE
Fix failure when only `script` is declared

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var nodemon = require('nodemon')
   , gulp = require('gulp')
 
 module.exports = function (settings) {
-  settings = settings || { script: '', args: '' }
+  settings = settings || {}
+  settings.script = settings.script || ''
+  settings.options = settings.options || ''
+
   options = ['nodemon', settings.script].concat(settings.options.split(' '))
 
   try {


### PR DESCRIPTION
When you only declare `script` you get this failure.

```
TypeError: Cannot call method 'split' of undefined
    at module.exports (/Users/shane/Sites/gulp-nodemon/index.js:8:66)
    at Gulp.<anonymous> (/Users/shane/Sites/solidweld/Gulpfile.js:11:3)
    at module.exports (/Users/shane/Sites/solidweld/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:33:7)
    at Gulp.Orchestrator._runTask (/Users/shane/Sites/solidweld/node_modules/gulp/node_modules/orchestrator/index.js:271:3)
    at Gulp.Orchestrator._runStep (/Users/shane/Sites/solidweld/node_modules/gulp/node_modules/orchestrator/index.js:212:10)
    at Gulp.Orchestrator.start (/Users/shane/Sites/solidweld/node_modules/gulp/node_modules/orchestrator/index.js:132:8)
    at Gulp.run (/Users/shane/Sites/solidweld/node_modules/gulp/index.js:21:14)
    at /usr/local/share/npm/lib/node_modules/gulp/bin/gulp.js:115:19
    at process._tickCallback (node.js:415:13)
    at Function.Module.runMain (module.js:499:11)
```

This fix will allow either `script` or `options` to truly be optional.
