### PR TITLE
Handle arguments that contain spaces.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var nodemon = require('nodemon')
-  , cli = require('nodemon/lib/cli')
   , colors = require('colors')
   , gulp = require('gulp')
 


### PR DESCRIPTION
Command-line arguments could contain spaces if they are quoted so `options.split(' ')` might not be a good idea. nodemon's `cli.parse()` handles these arguments correctly so why not just let nodemon parse `options`. Also, the `nodemon()` function calls `cli.parse()` internally so there's no need to parse the arguments beforehand.
