### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var nodemon = require('nodemon')
-  , colors = require('colors')
   , gulp = require('gulp')
+  , gutil = require('gulp-util')
 
 module.exports = function (options) {
   if (options.exec instanceof Array) options.exec = options.exec.join(' ')
@@ -18,7 +18,7 @@ module.exports = function (options) {
 
   // Forward log messages
   script.on('log', function (log) {
-    console.log('[gulp] ' + ('[nodemon] ' + log.message).yellow)
+    gutil.log(gutil.colors.yellow('[nodemon] ' + log.message))
   })
 
   // Shim 'on' for use with gulp tasks


### PR DESCRIPTION
Remove the 'colors' dependency and use the 'gulp-util' module instead. The 'gulp-util' log method will automatically prefix the message and give us the ability to color values.
