### PR TITLE
Allow nodemon to be called without an options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var nodemon = require('nodemon')
   , gulp = require('gulp')
 
 module.exports = function (options) {
+  options = options || {};
   if (options.exec instanceof Array) options.exec = options.exec.join(' ')
   if (typeof options.exec === 'string') options.exec = 'gulp ' + options.exec
 


### PR DESCRIPTION
This avoids an error when no options are given to `nodemon`. This can happy when all configuration information should be fetched from the `nodemon.json` file.
