### PR TITLE
move gulp from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
+    "gulp": "^3.8.10",
     "nodemon": "^1.3.1",
     "event-stream": "^3.2.1",
     "colors": "^1.0.3"
   },
   "devDependencies": {
-    "gulp": "^3.8.10",
     "should": "^4.0.0",
     "gulp-jshint": "^1.6.1",
     "gulp-mocha": "^0.2.0",


### PR DESCRIPTION
For a development package gulp is a normal dependency not a development one. It is required in the main ```index.js``` file