### PR TITLE
Fix empty tasks array running default tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,6 +70,7 @@ module.exports = function (options) {
   // Synchronous alternative to gulp.run()
   function run(tasks) {
     if (typeof tasks === 'string') tasks = [tasks]
+    if (tasks.length === 0) return
     if (!(tasks instanceof Array)) throw new Error('Expected task name or array but found: ' + tasks)
     cp.spawnSync('gulp', tasks, { stdio: [0, 1, 2] })
   }


### PR DESCRIPTION
I sometimes want to simply restart the server if I edit a file with an extension I'm currently watching without adding any tasks to the task array.

Example: My stack only has tasks to process the front end js and not the backend. If I edit a backend js file, I don't want to run the front end js tasks. However, if the task array is empty - then it reruns all the default tasks and tries to restart the server without shutting down generating a nasty error "Port already in use" error.

My example nodemon gulp task:
```javascript
gulp.task('develop', ['javascript', 'fileinclude', 'css'], function() {
	nodemon({
		script: 'server.js',
		ext: 'html scss js',
		verbose: true,
		ignore: [
			'public/assets/js/*',
			'public/dst/*',
			'node_modules/*',
			'.git'
		],
		tasks: function(changedFiles) {
			var tasks = [];
			changedFiles.forEach(function (file) {
				if (path.parse(file).dir.indexOf('public/app') !== -1 && path.extname(file) === '.js' && !~tasks.indexOf('javascript')) {
					tasks.push('javascript');
				}
				if (path.extname(file) === '.scss' && !~tasks.indexOf('css')) {
					tasks.push('css');
				}
				if (path.extname(file) === '.html' && !~tasks.indexOf('fileinclude')) {
					tasks.push('fileinclude');
				}
			})
			return tasks;
		}
	})
	.on('restart', function() {
		console.log('Restarted');
	});
});

gulp.task('default', ['javascript', 'fileinclude', 'css', 'develop']);
```