### PR TITLE
Temporarily pin to nodemon 1.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
     "gulp": "^3.8.11",
-    "nodemon": "^1.3.7",
+    "nodemon": "1.3.7",
     "event-stream": "^3.2.1",
     "colors": "^1.0.3"
   },


### PR DESCRIPTION
Temporary fix for https://github.com/JacksonGariety/gulp-nodemon/issues/80.