### PR TITLE
Spawn 'gulp.cmd' instead of 'gulp' on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,6 @@ module.exports = function (options) {
   function run(tasks) {
     if (typeof tasks === 'string') tasks = [tasks]
     if (!(tasks instanceof Array)) throw new Error('Expected task name or array but found: ' + tasks)
-    cp.spawnSync('gulp', tasks, { stdio: [0, 1, 2] })
+    cp.spawnSync(process.platform === 'win32' ? 'gulp.cmd' : 'gulp', tasks, { stdio: [0, 1, 2] })
   }
 }


### PR DESCRIPTION
Fixes https://github.com/JacksonGariety/gulp-nodemon/issues/78 and https://github.com/JacksonGariety/gulp-nodemon/issues/81.

As per @luketurner's [comment](https://github.com/JacksonGariety/gulp-nodemon/issues/78#issuecomment-119710186) on https://github.com/JacksonGariety/gulp-nodemon/issues/78:
> …if you are on Windows you may have a problem with the way it spawns the process, because it launches the executable `gulp`, but on Windows the actual executable is called `gulp.cmd`. This can be fixed by changing the spawned executable name on line 74 from `gulp` to `gulp.cmd`.