### PR TITLE
Fixing an issue caused by a recent nodemon update that includes an up…

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
     "gulp": "^3.8.11",
-    "nodemon": "^1.4.1",
+    "nodemon": "<=1.7.1",
     "event-stream": "^3.2.1",
     "colors": "^1.0.3"
   },


### PR DESCRIPTION
…date to chokidar 1.2.0, which adds some extra fun for add and addDir events. The ready event is getting posted multiple times for arrays of file globs, and after the first one is received by nodemon, it's causing all other add events to trigger a restart of the application. Limiting gulp-nodemon to loading up through nodemon 1.7.1 seems to fix this issue for now, but is only a bandaid over the actual problem. Running vanilla nodemon doesn't seem to cause this issue, so I don't know if it's something to do with the handoff of the file array from gulp-nodemon to nodemon, or something else. I'll leave that up to the project author(s) to determine, and submit this quickie patch to solve the problem for now.