### PR TITLE
Hijack internal nodemon bus in order to always catch restart regardless of logging options

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function (options) {
 
     // Place our listener in first position
     bus.on('restart', function (files) {
-      nodemonLog("running tasks...")
+      if (!options.quiet) nodemonLog("running tasks...")
 
       if (typeof options.tasks === 'function') run(options.tasks(files))
       else run(options.tasks)

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ var nodemon = require('nodemon')
 
 module.exports = function (options) {
   options = options || {};
-  if (typeof options.tasks === 'function') options.verbose = true // Enable verbose mode if file change list is needed
 
   // Our script
   var script = nodemon(options)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var nodemon = require('nodemon')
   , colors = require('colors')
   , gulp = require('gulp')
   , cp = require('child_process')
+  , bus = require('nodemon/lib/utils/bus')
 
 module.exports = function (options) {
   options = options || {};
@@ -12,22 +13,22 @@ module.exports = function (options) {
   // Our script
   var script = nodemon(options)
     , originalOn = script.on
+    , originalListeners = bus.listeners('restart')
 
   // Allow for injection of tasks on file change
   if (options.tasks) {
-    if (options.verbose) {
-      script.on('log', function (log) {
-        if (~log.message.indexOf('files triggering change check')) {
-          if (typeof options.tasks === 'function') run(options.tasks(log.message.split('files triggering change check: ').pop().split(' ')))
-          else run(options.tasks)
-        }
-      })
-    } else {
-      script.on('log', function (log) {
-        if (~log.message.indexOf('restarting due to changes...')) {
-          run(options.tasks)
-        }
-      })
+    // Remove all 'restart' listeners
+    bus.removeAllListeners('restart');
+
+    // Place our listener in first position
+    bus.on('restart', function () {
+      nodemonLog("running tasks...")
+      run(options.tasks)
+    })
+
+    // Re-add all other listeners
+    for (var i = 0; i < originalListeners.length; i++) {
+      bus.on('restart', originalListeners[i])
     }
   }
 
@@ -36,9 +37,9 @@ module.exports = function (options) {
 
   // Forward log messages and stdin
   script.on('log', function (log) {
-    console.log('[' + new Date().toString().split(' ')[4].gray + '] ' + ('[nodemon] ' + log.message).yellow)
+    nodemonLog(log.message)
   })
-  
+
   // Shim 'on' for use with gulp tasks
   script.on = function (event, tasks) {
     var tasks = Array.prototype.slice.call(arguments)
@@ -74,4 +75,8 @@ module.exports = function (options) {
     if (!(tasks instanceof Array)) throw new Error('Expected task name or array but found: ' + tasks)
     cp.spawnSync(process.platform === 'win32' ? 'gulp.cmd' : 'gulp', tasks, { stdio: [0, 1, 2] })
   }
+}
+
+function nodemonLog(message) {
+  console.log('[' + new Date().toString().split(' ')[4].gray + '] ' + ('[nodemon] ' + message).yellow)
 }

--- a/index.js
+++ b/index.js
@@ -21,9 +21,11 @@ module.exports = function (options) {
     bus.removeAllListeners('restart');
 
     // Place our listener in first position
-    bus.on('restart', function () {
+    bus.on('restart', function (files) {
       nodemonLog("running tasks...")
-      run(options.tasks)
+
+      if (typeof options.tasks === 'function') run(options.tasks(files))
+      else run(options.tasks)
     })
 
     // Re-add all other listeners


### PR DESCRIPTION
I've been playing with gulp-nodemon and trying to compose my own gulp script that would mix testing and running my application, orchestrating restarts whenever anything changes using nodemon.

In order to make the test output more readable while using gulp, I started using the `quiet` option, and passing it as an option to gulp-nodemon. Everything seemed like it would be fine, but I then started noticing that my code, while still being re-run, was not being recompiled.

Peering through the sourcecode revealed the reason behind this is that gulp-nodemon depends on the log output of nodemon to work, even making exceptions for when the `verbose` option is enabled. Obviously, this falls apart when nodemon is set to `quiet`, as it will simply not log anything.

I've patched this behavior in order to depend on nodemon's `restart` event, instead. However, making this change without further additions leads to the application being restarted **before** gulp gets a chance to run its tasks, which is not good for the users of gulp-nodemon.

In order to work around this issue, I added some code that, by accessing the internal "event bus" used by nodemon, puts gulp-nodemon's event listener for `restart` before all others, so that gulp will get a chance to run **before** the code is re-run.

In my limited testing, everything appears to continue working fine after this change, and the `quiet` option doesn't produce annoying gotchas anymore.

------

I can definitely see potential reasons why this PR shouldn't be merged, primarily the use of an implementation detail in nodemon to achieve the purpose of this change, and the weird way of removing listeners and then re-adding them in the right order.

I'd like to argue, however, that this method may make more sense than the old way of intercepting restarts, for the following reasons:

 - The original way of listening to `log` events, and comparing against the verbatim string that nodemon logs could also lead to issues in the (rare, but not impossible) case of said output changing;
 - The `verbose` option had to be forced on by gulp-nodemon in the case of the user passing `options.tasks` as a function. This may lead to potentially unwanted output or other side-effects. Using the `restart` event, allows us to achieve the same functionality without the need to enable the `verbose` mode;
 - Listening to `restart` events allows us to write more informative output, in this case adding a message saying `running tasks...` before tasks are run (earlier, it would only say `restarting due to changes...`, which is not extremely indicative of what's happening).


Let me know if this PR is useful, or if there's anything I can do to improve it!