### PR TITLE
Update deps, swap to gulp4

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,7 +10,7 @@ var gulp = require('gulp')
 // })
 
 gulp.task('lint', function () {
-  gulp.src('./*/**.js')
+  return gulp.src('./*/**.js')
     .pipe(jshint())
 })
 
@@ -20,7 +20,7 @@ gulp.task('afterstart', function () {
   console.log('proc has finished restarting!')
 })
 
-gulp.task('test', ['lint'], function () {
+gulp.task('test', gulp.series(['lint']), function () {
   nodemon({
       script: './test/server.js'
     , verbose: true

--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
   },
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
-    "gulp": "^3.8.11",
-    "nodemon": "^1.9.2",
-    "event-stream": "^3.2.1",
-    "colors": "^1.0.3"
+    "gulp": "github:gulpjs/gulp#4.0",
+    "nodemon": "^1.10.0",
+    "event-stream": "^3.3.4",
+    "colors": "^1.1.2"
   },
   "devDependencies": {
-    "should": "^4.0.0",
-    "gulp-jshint": "^1.6.1",
-    "gulp-mocha": "^0.2.0",
-    "is-running": "^1.0.3",
-    "coffee-script": "^1.7.1"
+    "should": "^10.0.0",
+    "gulp-jshint": "^2.0.1",
+    "gulp-mocha": "^2.2.0",
+    "is-running": "^2.0.0",
+    "coffee-script": "^1.10.0"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Hello!

  This PR updates us to newest deps and gulp4, which significantly reduces dep duplication for those of us using gulp4.

  Perhaps this shouldn't be merged until Gulp4 is GA, but either way it works fine for me (I've been using it for development for a few days now, no issues).

  Thanks!
