### PR TITLE
Added support for forcing nodemon events

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -21,7 +21,7 @@ gulp.task('afterstart', function () {
 })
 
 gulp.task('test', ['lint'], function () {
-  nodemon({
+  var stream = nodemon({
       script: './test/server.js'
     , verbose: true
     , env: {
@@ -40,5 +40,11 @@ gulp.task('test', ['lint'], function () {
     //   }
     // , nodeArgs: ['--debug']
     })
+
+  stream
     .on('restart', 'cssmin')
+    .on('crash', function (){
+      console.error('Application has crashed!\n')
+      stream.emit('restart', 2)
+    })
 })

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ gulp-nodemon returns a stream just like any other NodeJS stream, **except for th
 1. `[event]` is an event name as a string. See [nodemon events](https://github.com/remy/nodemon/blob/master/doc/events.md).
 2. `[tasks]` An array of gulp task names or a function to execute.
 
+### **.emit(event, [Number])**
+1. `event`   is an event name as a string. See [nodemon events](https://github.com/remy/nodemon/blob/master/doc/events.md).
+2. `timeout` is an _optional_ delay, in seconds, to emit `event`. 
+
 ## Examples
 
 ### Basic Usage
@@ -87,13 +91,19 @@ gulp.task('lint', function () {
 })
 
 gulp.task('develop', function () {
-  nodemon({ script: 'server.js'
+  var stream = nodemon({ script: 'server.js'
           , ext: 'html js'
           , ignore: ['ignored.js']
           , tasks: ['lint'] })
-    .on('restart', function () {
-      console.log('restarted!')
-    })
+          
+  stream
+      .on('restart', function () {
+        console.log('restarted!')
+      })
+      .on('crash', function() {
+        console.error('Application has crashed!\n')
+         stream.emit('restart', 10)  // restart the server in 10 seconds
+      })
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ gulp-nodemon returns a stream just like any other NodeJS stream, **except for th
 2. `[tasks]` An array of gulp task names or a function to execute.
 
 ### **.emit(event, [Number])**
-1. `event`   is an event name as a string. See [nodemon events](https://github.com/remy/nodemon/blob/master/doc/events.md).
+1. `event`   is an event name as a string. See [nodemon events](https://github.com/remy/nodemon/blob/master/doc/events.md#using-nodemon-events).
 2. `timeout` is an _optional_ delay, in seconds, to emit `event`. 
 
 ## Examples

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = function (options) {
   // Our script
   var script = nodemon(options)
     , originalOn = script.on
+    , originalEmit = script.emit
     , originalListeners = bus.listeners('restart')
 
   // Allow for injection of tasks on file change
@@ -70,6 +71,26 @@ module.exports = function (options) {
     }
 
     return script
+  }
+
+  // Shim 'emit' for use with gulp
+  script.emit = function (event, timeoutInSecs){
+    if (typeof event !== 'string')
+      throw new Error('Event must be a string!')
+
+    if (!timeoutInSecs) {
+      console.info('restarting')
+      originalEmit(event)
+    }
+
+    else if (typeof timeoutInSecs !== 'number')
+      throw new Error('Timeout must be a number!')
+    else {
+      console.info('restarting in ' + timeoutInSecs + 'secs')
+      setTimeout(function (){
+        originalEmit(event)
+      }, timeoutInSecs * 1000)
+    }
   }
 
   return script

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   },
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
-    "gulp": "^3.8.11",
-    "nodemon": "^1.9.2",
+    "colors": "^1.0.3",
     "event-stream": "^3.2.1",
-    "colors": "^1.0.3"
+    "gulp": "^3.8.11",
+    "nodemon": "^1.10.2"
   },
   "devDependencies": {
     "should": "^4.0.0",


### PR DESCRIPTION
This enables you to do something like:
```js
const stream = nodemon( { ... } )

stream
    .on('restart', 'cssmin')
    .on('crash', function (){
      console.error('Application has crashed!\n')
      stream.emit('restart', 2)  // restart the server in 2 seconds
    })
```

This fixes #50 