### PR TITLE
Updated README with more clearly explanation of the 'tasks' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,16 @@ nodemon({
 ```
 
 What if you want to decouple your build processes by language? Or even by file? Easy, just set the `tasks` option to a function. Gulp-nodemon will pass you the list of changed files and it'll let you return a list of tasks you want run.
+
+*NOTE:* If you manually restart the server (`rs`) this function will receive a `changedFiles === undefined` so check it and return the `tasks` because it expects an array to be returned.
+
 ```js
 nodemon({
   script: './index.js'
 , ext: 'js css'
 , tasks: function (changedFiles) {
     var tasks = []
+    if (!changedFiles) return tasks;
     changedFiles.forEach(function (file) {
       if (path.extname(file) === '.js' && !~tasks.indexOf('lint')) tasks.push('lint')
       if (path.extname(file) === '.css' && !~tasks.indexOf('cssmin')) tasks.push('cssmin')


### PR DESCRIPTION
I've decided to document this unexpected behavior, but it can be changed in the internal code, the issue is the following.

If you restart the server manually (`rs`) the `changedFiles` is `undefined`, so you can not `forEach` it, so you have to check for it. On the example I did an early return but there are other options. Also the `tasks` function expects an Array to be returned so the empty tasks has to be returned.

I can change the PR or add more things if you want :).