### PR TITLE
Update gulp to 4.x.x

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,18 +10,20 @@ var gulp    = require('gulp')
 // })
 
 gulp.task('lint', function (){
-  gulp.src('./*/**.js')
+  return gulp.src('./*/**.js')
     .pipe(jshint())
 })
 
-gulp.task('cssmin', function (){ /* void */
+gulp.task('cssmin', function (done){
+  done();
 })
 
-gulp.task('afterstart', function (){
-  console.log('proc has finished restarting!')
+gulp.task('afterstart', function (done){
+  console.log('proc has finished restarting!');
+  done();
 })
 
-gulp.task('test', ['lint'], function () {
+gulp.task('test', gulp.series('lint', function (done){
   var stream = nodemon({
       nodemon: require('nodemon')
     , script: './test/server.js'
@@ -31,6 +33,7 @@ gulp.task('test', ['lint'], function () {
       }
     , watch: './'
     , ext: 'js coffee'
+    , done: done
   })
 
   stream
@@ -42,4 +45,4 @@ gulp.task('test', ['lint'], function () {
         stream.emit('restart')
       }, 2000)
     })
-})
+}))

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ You can pass an object to gulp-nodemon with options [like you would in nodemon c
 
 Example below will start `server.js` in `development` mode and watch for changes, as well as watch all `.html` and `.js` files in the directory.
 ```js
-gulp.task('start', function () {
+gulp.task('start', function (done) {
   nodemon({
     script: 'server.js'
   , ext: 'js html'
   , env: { 'NODE_ENV': 'development' }
+  , done: done
   })
 })
 ```
@@ -93,11 +94,12 @@ gulp.task('lint', function () {
     .pipe(jshint())
 })
 
-gulp.task('develop', function () {
+gulp.task('develop', function (done) {
   var stream = nodemon({ script: 'server.js'
           , ext: 'html js'
           , ignore: ['ignored.js']
           , tasks: ['lint'] })
+          , done: done
 
   stream
       .on('restart', function () {
@@ -123,7 +125,7 @@ gulp.task('pluggable', function() {
 The [bunyan](https://github.com/trentm/node-bunyan/) logger includes a `bunyan` script that beautifies JSON logging when piped to it. Here's how you can you can pipe your output to `bunyan` when using `gulp-nodemon`:
 
 ```js
-gulp.task('run', ['default', 'watch'], function() {
+gulp.task('run', ['default', 'watch'], function(done) {
     var nodemon = require('gulp-nodemon'),
         spawn   = require('child_process').spawn,
         bunyan
@@ -137,7 +139,8 @@ gulp.task('run', ['default', 'watch'], function() {
         ],
         watch:    [paths.etc, paths.src],
         stdout:   false,
-        readable: false
+        readable: false,
+        done: done
     })
     .on('readable', function() {
 
@@ -181,11 +184,12 @@ gulp.task('compile', function () {
   return stream // important for gulp-nodemon to wait for completion
 })
 
-gulp.task('watch', ['compile'], function () {
+gulp.task('watch', ['compile'], function (done) {
   var stream = nodemon({
                  script: 'dist/' // run ES5 code
                , watch: 'src' // watch ES2015 code
                , tasks: ['compile'] // compile synchronously onChange
+               , done: done
                })
 
   return stream

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-nodemon",
-  "version": "2.3.0",
+  "version": "3.0.0",
   "description": "it's gulp + nodemon + convenience",
   "main": "index.js",
   "scripts": {
@@ -28,10 +28,10 @@
   },
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
-    "colors": "^1.0.3",
-    "event-stream": "^3.2.1",
-    "gulp": "^3.9.1",
-    "nodemon": "^1.10.2"
+    "colors": "^1.2.1",
+    "event-stream": "^3.3.4",
+    "gulp": "^4.0.0",
+    "nodemon": "^1.17.3"
   },
   "devDependencies": {
     "should": "^4.0.0",


### PR DESCRIPTION
gulp recommends everyone to update v4 and deprecate gulp-utils. gulp v4 also has better support for running tasks in series or in parallel.