### PR TITLE
Increase visibility of the gulp command output

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,10 @@ module.exports = function (options) {
     if (!(tasks instanceof Array)) throw new Error('Expected task name or array but found: ' + tasks)
     var gulpPath = path.join(process.cwd(), 'node_modules/.bin/')
     var gulpCmd = path.join(gulpPath, process.platform === 'win32' ? 'gulp.cmd' : 'gulp')
-    cp.spawnSync(gulpCmd, tasks, { stdio: [0, 1, 2] });
+    var result = cp.spawnSync(gulpCmd, tasks, { stdio: [0, 1, 2] });
+
+    if (option.loglevel === 'debug' || result.error) console.log(result.stdout);
+    if (result.error !== undefined) console.error(result.stderr, result.error);
   }
 }
 


### PR DESCRIPTION
Log the output of the gulp command if a debug log level is provided or if the command errors out.