### PR TITLE
Use debounce to trigger gulp tasks only once for multiple file changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "colors": "^1.2.1",
     "event-stream": "^3.3.4",
     "gulp": "^4.0.0",
+    "lodash.debounce": "^4.0.8",
     "nodemon": "^1.17.5"
   },
   "devDependencies": {


### PR DESCRIPTION
See #160 for description of problem.