### PR TITLE
fix: pin colors@1.4.0 to fix security vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/JacksonGariety/gulp-nodemon",
   "dependencies": {
-    "colors": "^1.2.1",
+    "colors": "1.4.0",
     "gulp": "^4.0.0",
     "nodemon": "^2.0.2"
   },


### PR DESCRIPTION
A Security Vuln was identified in the Colors package for >1.4.0, offending packages being `1.4.1`, `1.4.44-liberty`
- [source1](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source2](https://twitter.com/snyksec/status/1480286811482206216?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Etweet)
- [source3](https://security.snyk.io/vuln/SNYK-JS-COLORS-2331906)

This PR pins the color package to `1.4.0` as advised on the [snyk page](https://snyk.io/blog/open-source-maintainer-pulls-the-plug-on-npm-packages-colors-and-faker-now-what/)